### PR TITLE
Patch ++delete security hole

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -32,6 +32,9 @@ var pastWords = []
 var turn = 0
 var objected = 0
 
+/* PUT SOMETHING IN HERE; TEMPORARY FIX FOR HUGE SECURITY HOLE */
+var isModerator = (author) => false;
+
 /* DATA RECEIVAL/DISTRIBUTION */
 var sendDataToFile = (index, datum, callback) => {
   fs.readFile(options.jsonFile, {encoding: 'utf8'}, (error, individualData) => {
@@ -171,6 +174,8 @@ var commands = {
     }
   },
   'delete': (message, args) => {
+    if (!isModerator(message.author)) return;
+    
     var number = args[0] * 1
     if (isNaN(number)) {
       message.channel.sendMessage('Dat not a number')


### PR DESCRIPTION
Anyone can use ++delete on other's messages. This patch introduces an `isModerator` function on whose failure results in the termination of ++delete. **THIS IS A TEMPORARY FIX.**

I propose a separate list of moderator commands that go through permission checks before execution.

Currently, `isModerator` returns `false` every time. I do not suggest fixing this; I do suggest the above proposition.